### PR TITLE
make "fresh open" work even when $EDITOR is a command with parameters

### DIFF
--- a/bin/fresh-open
+++ b/bin/fresh-open
@@ -20,4 +20,4 @@ if ! [[ -d "$DIRECTORY" ]]; then
 fi
 
 cd "$DIRECTORY"
-exec "$EDITOR" "$DIRECTORY"
+eval exec "$EDITOR" "$DIRECTORY"


### PR DESCRIPTION
for instance, my `$EDITOR` is set to `"emacs -nw -Q"` and `fresh open` does not work directly with only `exec`.